### PR TITLE
Use constants from config when creating a game scene.

### DIFF
--- a/src/menu_scenes.cpp
+++ b/src/menu_scenes.cpp
@@ -19,7 +19,7 @@ void MenuScene::update() {
     if (buttons.released & Button::A) {
         switch (option_selected) {
             case 0: // Game
-                finish(new GameScene(16, 16, 40));
+                finish(new GameScene(board_width, board_height, 40));
                 break;
             case 1: // Credits
                 finish(new CreditsScene());


### PR DESCRIPTION
Fixes bug with hidden extra row (wrong hardcoded board height)